### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server that enables AI assistants like Claude to interact with Unity projects programmatically. Supports both Claude Desktop integration and HTTP API for flexible development workflows.
 
+<a href="https://glama.ai/mcp/servers/@zabaglione/mcp-server-unity">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zabaglione/mcp-server-unity/badge" alt="Server for Unity MCP server" />
+</a>
+
 ## Features
 
 ### 📦 Core Features


### PR DESCRIPTION
This PR adds a badge for the [MCP Server for Unity](https://glama.ai/mcp/servers/@zabaglione/mcp-server-unity) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@zabaglione/mcp-server-unity">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zabaglione/mcp-server-unity/badge" alt="Server for Unity MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.