### PR TITLE
Add Newtonsoft JSON installation instructions to README files

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -28,7 +28,7 @@ Claudeに話しかけるだけで：
 
 3. **使ってみよう！**
    - Unityプロジェクト（2019.4以降）を開く
-   - UnityにNewtonSoft JSONパッケージをインストール：
+   - UnityにNewtonsoft JSONパッケージをインストール：
      - ウィンドウ → Package Managerを開く
      - 「+」ボタンをクリックして「Add package by name...」を選択
      - 入力：`com.unity.nuget.newtonsoft-json`

--- a/README-ja.md
+++ b/README-ja.md
@@ -28,6 +28,11 @@ Claudeに話しかけるだけで：
 
 3. **使ってみよう！**
    - Unityプロジェクト（2019.4以降）を開く
+   - UnityにNewtonSoft JSONパッケージをインストール：
+     - ウィンドウ → Package Managerを開く
+     - 「+」ボタンをクリックして「Add package by name...」を選択
+     - 入力：`com.unity.nuget.newtonsoft-json`
+     - 「Add」をクリック
    - Claudeに依頼：「/path/to/projectにUnity MCPをセットアップして」
    - Claudeが自動的にすべてをインストールします！
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Talk to Claude to:
 
 3. **Start Using!**
    - Open any Unity project (2019.4 or newer)
+   - Install NewtonSoft JSON package in Unity:
+     - Open Window → Package Manager
+     - Click the "+" button and select "Add package by name..."
+     - Enter: `com.unity.nuget.newtonsoft-json`
+     - Click "Add"
    - Ask Claude: "Setup Unity MCP in my project at /path/to/project"
    - Claude will install everything automatically!
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Talk to Claude to:
 
 3. **Start Using!**
    - Open any Unity project (2019.4 or newer)
-   - Install NewtonSoft JSON package in Unity:
+   - Install Newtonsoft JSON package in Unity:
      - Open Window → Package Manager
      - Click the "+" button and select "Add package by name..."
      - Enter: `com.unity.nuget.newtonsoft-json`


### PR DESCRIPTION
# Add Newtonsoft JSON installation instructions to README files

## 概要 / Overview
README.mdとREADME-ja.mdの「使ってみよう！」セクションに、Newtonsoft JSONパッケージのインストール手順を追加しました。

Added Newtonsoft JSON package installation instructions to the "Quick Start" section in both README.md and README-ja.md files.

## 変更内容 / Changes Made

### README.md
- **Section**: "3. **Start Using!**"
- **Location**: After "Open any Unity project (2019.4 or newer)"
- **Added**: Newtonsoft JSON package installation steps

### README-ja.md  
- **Section**: "3. **使ってみよう！**"
- **Location**: After "Unityプロジェクト（2019.4以降）を開く"
- **Added**: Newtonsoft JSONパッケージのインストール手順

## 追加した手順 / Added Instructions

**English:**
```
- Install Newtonsoft JSON package in Unity:
  - Open Window → Package Manager
  - Click the "+" button and select "Add package by name..."
  - Enter: `com.unity.nuget.newtonsoft-json`
  - Click "Add"
```

**Japanese:**
```
- UnityにNewtonsoft JSONパッケージをインストール：
  - ウィンドウ → Package Managerを開く
  - 「+」ボタンをクリックして「Add package by name...」を選択
  - 入力：`com.unity.nuget.newtonsoft-json`
  - 「Add」をクリック
```

## 理由 / Rationale

Unity MCP Serverを使用する際に、Newtonsoft JSONパッケージが必要な場合があります。この手順を事前に追加することで：

When using Unity MCP Server, the Newtonsoft JSON package may be required. By adding these instructions upfront:

- ユーザーが必要な依存関係を事前にインストールできる / Users can install necessary dependencies in advance
- セットアップ時のエラーを防ぐことができる / Prevents setup errors
- より良いユーザーエクスペリエンスを提供する / Provides better user experience

## テスト / Testing

- ✅ 両方のREADMEファイルの構文と形式を確認
- ✅ インストール手順の正確性を確認
- ✅ 既存のドキュメント構造を維持

- ✅ Verified syntax and formatting of both README files
- ✅ Confirmed accuracy of installation instructions  
- ✅ Maintained existing documentation structure

## 関連 / Related

- Package: `com.unity.nuget.newtonsoft-json`
- Unity Package Manager documentation
- Unity MCP Server setup requirements